### PR TITLE
autorun no longer implicitly re-running on state change

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'std:tracker-component',
-  version: '1.3.21',
+  version: '1.4.0',
   summary: 'Easy reactive React Components with Meteor and Tracker',
   git: 'https://github.com/studiointeract/tracker-component',
   documentation: 'README.md'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracker-component",
-  "version": "1.3.21",
+  "version": "1.4.0",
   "description": "Easy reactive React Components with Meteor and Tracker",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Breaking change. Should we up the version to 2.0.0?

This changes the behavior so that autorun blocks are no longer invalidated whenever there is a state change. They will re-run whenever there are prop changes though. I've added getState that should allow subscribing to a part of the state in an autorun block but that part is untested.

TODO:
- Documentation updates (?)
