### PR TITLE
return computation from this.autorun

### DIFF
--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -15,9 +15,13 @@ Tracker.Component = class extends React.Component {
       this.__subscribe.apply(this, [name, ...options]);
   }
 
-  autorun(fn) { return this.__comps.push(Tracker.autorun(c => {
-    this.__live = true; fn(c); this.__live = false;
-  }))}
+  autorun(fn) {
+    const computation = Tracker.autorun(c => {
+      this.__live = true; fn(c); this.__live = false;
+    })
+    this.__comps.push(computation)
+    return computation
+  }
 
   componentDidUpdate() { !this.__live && this.__comps.forEach(c => {
     c.invalidated = c.stopped = false; !c.invalidate();


### PR DESCRIPTION
`this.__comps.push` return the index of the pushed element.
`Tracker.autorun` and `this.autorun` in Blaze return the computation.
I think that was tried to achieve with 07400b29e86ff1f5efb1bb07aca889f195778a7d
